### PR TITLE
Fix default value for implicit conversion.

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 ## [yy.ddd] - tbd
 - Nothing yet...
 
+## [0.5] - 2022-11-04
+- Fix default value for implicit conversion.
+
 ## [0.4] - 2022-02-02
 - Update for osx-arm64, ppc64le.
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CRENDER
 Version
 -------
 
-This is version 0.4.
+This is version 0.5.
 
 General
 -------

--- a/src/yaml.cc
+++ b/src/yaml.cc
@@ -244,12 +244,12 @@ bool cr_read_file(const char *fname, std::string &fcontent, bool do_preprocess, 
       jinja2::ArgInfo{ "subpackage_name" },
       jinja2::ArgInfo{ "min_pin", false, "x.x.x.x.x.x" },
       jinja2::ArgInfo{ "max_pin", false, "x" },
-      jinja2::ArgInfoT<bool>{ "exact", false, 0});
+      jinja2::ArgInfoT<bool>{ "exact", false, false});
   params["pin_compatible"] = jinja2::MakeCallable(expand_pin_subpackage,
       jinja2::ArgInfo{ "subpackage_name" },
       jinja2::ArgInfo{ "min_pin", false, "x.x.x.x.x.x" },
       jinja2::ArgInfo{ "max_pin", false, "x" },
-      jinja2::ArgInfoT<bool>{ "exact", false, 0 });
+      jinja2::ArgInfoT<bool>{ "exact", false, false });
   params["ccache"] = jinja2::MakeCallable(expand_ccache,
       jinja2::ArgInfo{ "method", false, "none" });
   // base python conversion routines

--- a/src/yaml.h
+++ b/src/yaml.h
@@ -4,7 +4,7 @@
 #include <string>
 #include "yaml-cpp/yaml.h"
 
-#define CRENDER_VERSION "0.4"
+#define CRENDER_VERSION "0.5"
 
 bool cr_read_file(const char *fname, std::string &fcontent, bool do_preprocess = true, bool do_jinja2 = true);
 


### PR DESCRIPTION
ArgInfoT<type>()'s default value must either be a Value<T> or a value that will implicitly convert to a Value<T>. 0 is an int and creates a Value<int> where we need a Value<bool>.